### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Contrib
+
+---
+Find the latest information at <https://unifiedpush.org>
+---
+
 Gateways, Proxies, and more
 
 You can find definitions of Gateway and Rewrite proxy on the [specifications](https://github.com/UnifiedPush/specifications).

--- a/distributors.md
+++ b/distributors.md
@@ -1,5 +1,9 @@
 # Distributors
 
+---
+Find updated information at <https://unifiedpush.org/users/intro/#install-a-distributor>
+---
+
 ## Gotify
 * [Sources](https://github.com/gotify)
 * [F-Droid](https://f-droid.org/packages/com.github.gotify) You need to add this repo first: repo.unifiedpush.org

--- a/gateways/README.md
+++ b/gateways/README.md
@@ -1,5 +1,9 @@
 # Gateways
 
+---
+Find the latest information at https://unifiedpush.org/developers/gateway/
+---
+
 See the [definition](https://github.com/UnifiedPush/specifications/blob/main/definitions.md#push-gateway).
 
 Gateways are meant to be hosted by the application developpers. To improve sel-hosting, gateways and applications may implement a discover functionnality.

--- a/gateways/matrix.md
+++ b/gateways/matrix.md
@@ -1,5 +1,9 @@
 # Matrix
 
+---
+Find the latest information at <https://unifiedpush.org/developers/gateway/#matrix>
+---
+
 ## Links
 
 * [Project](https://matrix.org)


### PR DESCRIPTION
Now that all equivalent information is on the website, we should deprecate this repo and link to the website to avoid duplication of information and people getting dated information.

If you agree with merging this, please also archive the repo from GitHub settings. All the new contrib-like information can then be maintained in the docs website.